### PR TITLE
Updated segmentation model/controller to use signals and disable/enable start button on segment run/finish

### DIFF
--- a/src/Controller/AutoSegmentationController.py
+++ b/src/Controller/AutoSegmentationController.py
@@ -1,4 +1,5 @@
 import threading
+from PySide6.QtCore import Slot
 from src.Model.AutoSegmentation import AutoSegmentation
 
 class AutoSegmentationController:
@@ -33,6 +34,9 @@ class AutoSegmentationController:
         To be called when the button to start the selected segmentation task is clicked
         :rtype: None
         """
+        # Disable start button while segmentation processes
+        self._view.set_start_button_status()
+
         self.run_task(self._view.get_segmentation_task(), self._view.get_fast_value())
 
     def update_progress_bar_value(self, value: int) -> None:
@@ -62,8 +66,24 @@ class AutoSegmentationController:
         :rtype: None
         """
         # Instantiate AutoSegmentation passing the required settings from the UI
-        auto_segmentation = AutoSegmentation(task, fast, controller=self)
+        auto_segmentation = AutoSegmentation(self)
 
         # Run tasks on separate thread
-        auto_seg_thread = threading.Thread(target=auto_segmentation.run_segmentation_workflow)
+        auto_seg_thread = threading.Thread(target=auto_segmentation.run_segmentation_workflow, args=(task, fast))
         auto_seg_thread.start() # Will auto terminate at the called functions conclusion
+
+    @Slot()
+    def on_segmentation_finished(self) -> None:
+        # Update the text edit UI
+        self.update_progress_bar_value(100)
+        self.update_progress_text("Segmentation Finished")
+
+        # Enable start button while segmentation processes
+        self._view.set_start_button_status()
+
+    @Slot()
+    def on_segmentation_error(self, error) -> None:
+        print("Segmentation Error from controller.")
+
+        # Enable start button while segmentation processes
+        self._view.set_start_button_status()

--- a/src/Model/AutoSegmentation.py
+++ b/src/Model/AutoSegmentation.py
@@ -41,7 +41,7 @@ class AutoSegmentation:
 
     def _create_copied_temporary_directory(self, dicom_dir):
         if not dicom_dir:
-            self.signals.error.emit('No dicom directory found')
+            self.signals.error.emit(f'No dicom directory found. Received dicom_dir={dicom_dir!r}')
             return
 
         try:

--- a/src/Model/Worker.py
+++ b/src/Model/Worker.py
@@ -4,6 +4,10 @@ import traceback
 
 from PySide6.QtCore import QObject, Signal, QRunnable, Slot
 
+class SegmentationWorkerSignals(QObject):
+    progress_updated = Signal(str)
+    finished = Signal()
+    error = Signal(str)
 
 class WorkerSignals(QObject):
     finished = Signal()

--- a/src/View/mainpage/AutoSegmentationTab.py
+++ b/src/View/mainpage/AutoSegmentationTab.py
@@ -178,6 +178,18 @@ class AutoSegmentationTab(QtWidgets.QWidget):
         self._progress_text.setTextCursor(cursor)
         self._progress_text.ensureCursorVisible()
 
+    def set_start_button_status(self):
+
+        self._start_button_enabled = not self._start_button_enabled
+
+        if self._start_button_enabled:
+            self._start_button.setEnabled(self._start_button_enabled)
+            self._start_button.setText("Start")
+        else:
+            #TODO: Set this to stop to end thread?
+            self._start_button.setEnabled(self._start_button_enabled)
+            self._start_button.setText("Wait")
+
     def _check_task_is_fast_compatible(self):
         """
         Protected method to check if the currently selected task


### PR DESCRIPTION
Removed direct calls to segmentation controller from segmentation model and replaced with signals
Added explicitly identified slots to controller to connect signals from model
Added function to segmentation tab to disable/enable start button when segmentation is run/finished
Added segmentation worker signals to exisiting Worker module

## Summary by Sourcery

Refactor segmentation workflow to use Qt signals/slots, integrate SegmentationWorkerSignals, and toggle the start button state during segmentation runs

New Features:
- Introduce SegmentationWorkerSignals with progress, finished, and error signals
- Add on_segmentation_finished and on_segmentation_error Qt slots in the controller
- Implement UI logic to disable and re-enable the start button during segmentation

Enhancements:
- Refactor AutoSegmentation to emit signals instead of direct controller calls and connect them to controller slots
- Update run_segmentation_workflow to accept task and fast parameters and emit progress updates via signals